### PR TITLE
Fix illegal reflection access in Java9+ 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ dependencies {
     jmh 'org.openjdk.jmh:jmh-generator-annprocess:1.21'
 }
 
+test{
+    useJUnitPlatform()
+}
+
 jmh {
     duplicateClassesStrategy 'warn'
 }

--- a/src/main/java/org/lanternpowered/lmbda/InternalMethodHandles.java
+++ b/src/main/java/org/lanternpowered/lmbda/InternalMethodHandles.java
@@ -109,7 +109,7 @@ final class InternalMethodHandles {
     private static @Nullable MethodHandle findPrivateLookupMethodHandle() {
         try {
             //noinspection JavaLangInvokeHandleSignature
-            return MethodHandles.publicLookup().findVirtual(MethodHandles.class, "privateLookupIn",
+            return MethodHandles.publicLookup().findStatic(MethodHandles.class, "privateLookupIn",
                     MethodType.methodType(MethodHandles.Lookup.class, Class.class, MethodHandles.Lookup.class));
         } catch (NoSuchMethodException | IllegalAccessException e) {
             return null;


### PR DESCRIPTION
Hey
I saw that even on Java 9+ the library used the adapter for Java 8 which led to illegal reflection accesses.
This was caused by the lookup for the "privateLookupIn" method expecting a non-static method (while in reality it is static).
So I made a small fix to prevent this issue.
I also made a small change in the Gradle build file to use the JUnitPlatform for testing, without that I had trouble at starting the tests manually with Gradle.

Keep up the good work :+1: 