### PR TITLE
Fix `ClassWriter` size issues to allow `ObjLongConsumer` to work

### DIFF
--- a/src/main/java/org/lanternpowered/lmbda/InternalLambdaFactory.java
+++ b/src/main/java/org/lanternpowered/lmbda/InternalLambdaFactory.java
@@ -270,7 +270,7 @@ public final class InternalLambdaFactory {
     final MethodHandle convertedMethodHandle = methodHandle.asType(methodType);
 
     final Method method = lambdaType.method;
-    final ClassWriter cw = new ClassWriter(0);
+    final ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
 
     final String packageName = InternalUtilities.getPackageName(defineLookup.lookupClass());
 
@@ -302,7 +302,7 @@ public final class InternalLambdaFactory {
     mv.visitVarInsn(ALOAD, 0);
     mv.visitMethodInsn(INVOKESPECIAL, Type.getInternalName(superclass), "<init>", "()V", false);
     mv.visitInsn(RETURN);
-    mv.visitMaxs(1, 1);
+    mv.visitMaxs(0, 0);
     mv.visitEnd();
 
     // Add the method handle field
@@ -313,7 +313,7 @@ public final class InternalLambdaFactory {
     mv.visitFieldInsn(PUTSTATIC, internalClassName, METHOD_HANDLE_FIELD_NAME,
       "Ljava/lang/invoke/MethodHandle;");
     mv.visitInsn(RETURN);
-    mv.visitMaxs(1, 0);
+    mv.visitMaxs(0, 0);
     mv.visitEnd();
 
     // Write the function method
@@ -335,7 +335,7 @@ public final class InternalLambdaFactory {
     mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/invoke/MethodHandle",
       "invokeExact", methodHandleDescriptor, false);
     mv.visitInsn(Type.getType(method.getReturnType()).getOpcode(IRETURN));
-    mv.visitMaxs(methodType.parameterCount() + 1, parameters.length + 1);
+    mv.visitMaxs(0, 0);
     mv.visitEnd();
 
     cw.visitEnd();

--- a/src/test/java/org/lanternpowered/lmbda/test/LambdaSetterTest.java
+++ b/src/test/java/org/lanternpowered/lmbda/test/LambdaSetterTest.java
@@ -19,24 +19,40 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.util.function.BiFunction;
 import java.util.function.ObjIntConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class LambdaSetterTest {
 
   @Test
-  void testField() throws Exception {
+  void testFieldInt() throws Exception {
     final MethodHandles.Lookup lookup =
       MethodHandlesExtensions.privateLookupIn(TestObject.class, MethodHandles.lookup());
-    final MethodHandle methodHandle = lookup.findSetter(TestObject.class, "data", int.class);
+    final MethodHandle methodHandle = lookup.findSetter(TestObject.class, "dataInt", int.class);
 
     final ObjIntConsumer<TestObject> setter = LambdaFactory.create(
       new LambdaType<ObjIntConsumer<TestObject>>() {}, methodHandle);
 
     final TestObject object = new TestObject();
-    assertEquals(100, object.getData());
+    assertEquals(100, object.getDataInt());
     setter.accept(object, 10000);
-    assertEquals(10000, object.getData());
+    assertEquals(10000, object.getDataInt());
+  }
+
+  @Test
+  void testFieldLong() throws Exception {
+    final MethodHandles.Lookup lookup =
+      MethodHandlesExtensions.privateLookupIn(TestObject.class, MethodHandles.lookup());
+    final MethodHandle methodHandle = lookup.findSetter(TestObject.class, "dataLong", long.class);
+
+    final ObjLongConsumer<TestObject> setter = LambdaFactory.create(
+      new LambdaType<ObjLongConsumer<TestObject>>() {}, methodHandle);
+
+    final TestObject object = new TestObject();
+    assertEquals(100, object.getDataLong());
+    setter.accept(object, 10000);
+    assertEquals(10000, object.getDataLong());
   }
 
   @Test
@@ -44,26 +60,35 @@ class LambdaSetterTest {
     final MethodHandles.Lookup lookup =
       MethodHandlesExtensions.privateLookupIn(TestObject.class, MethodHandles.lookup());
     final MethodHandle methodHandle = lookup.findVirtual(
-      TestObject.class, "setData", MethodType.methodType(void.class, int.class));
+      TestObject.class, "setDataInt", MethodType.methodType(void.class, int.class));
 
     final BiFunction<Object, Object, Object> setter = LambdaFactory.createBiFunction(methodHandle);
 
     final TestObject object = new TestObject();
-    assertEquals(100, object.getData());
+    assertEquals(100, object.getDataInt());
     setter.apply(object, 10000);
-    assertEquals(10000, object.getData());
+    assertEquals(10000, object.getDataInt());
   }
 
   public static class TestObject {
 
-    private int data = 100;
+    private int dataInt = 100;
+    private long dataLong = 100;
 
-    int getData() {
-      return this.data;
+    int getDataInt() {
+      return this.dataInt;
     }
 
-    void setData(int data) {
-      this.data = data;
+    void setDataInt(int dataInt) {
+      this.dataInt = dataInt;
+    }
+
+    long getDataLong() {
+      return this.dataLong;
+    }
+
+    void setDataLong(long dataLong) {
+      this.dataLong = dataLong;
     }
   }
 }


### PR DESCRIPTION
`ClassWriter` was being initialized with default flags, which caused runtime dynamic bytecode compilation errors, when attempting to compile a 

These only occurred when attempting to compile a setter using `ObjLongConsumer`, but `ObjIntConsumer` was fine.

Changes:
- Supply `ClassWriter` with the [`ClassWriter.COMPUTE_FRAMES`](https://asm.ow2.io/javadoc/org/objectweb/asm/ClassWriter.html#COMPUTE_FRAMES) flag ([further reading](https://stackoverflow.com/a/29334244))
- Remove redundant `org.objectweb.asm.MethodVisitor.visitMaxs(int, int)` size specifications following `ClassWriter.COMPUTE_FRAMES` addition
- Add test coverage for `ObjLongConsumer` alongside existing `ObjIntConsumer`

Fixes: https://github.com/LanternPowered/Lmbda/issues/6